### PR TITLE
cssBayan

### DIFF
--- a/cssBayan/css/style.css
+++ b/cssBayan/css/style.css
@@ -6,17 +6,7 @@
   border: 0;
 }
 
-*, *:before, *:after {
-  box-sizing: border-box;
-}
 
-:focus, :active {
-  outline: none;
-}
-
-a:focus, a:active {
-  outline: none;
-}
 
 nav, footer, header, aside {
   display: block;
@@ -27,7 +17,7 @@ html, body {
   width: 100%;
   font-size: 100%;
   line-height: 1;
-  font-size: 14px;
+
   -ms-text-size-adjust: 100%;
   -moz-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -50,9 +40,7 @@ button::-moz-focus-inner {
   border: 0;
 }
    
-a, a:visited {
-  text-decoration: none;
-}
+
 
 a:hover {
   text-decoration: none;
@@ -62,9 +50,7 @@ ul li {
   list-style: none;
 }
 
-img {
-  vertical-align: top;
-}
+
 
 h1, h2, h3, h4, h5, h6 {
   font-size: inherit;
@@ -75,7 +61,7 @@ h1, h2, h3, h4, h5, h6 {
 body{
   font-family: 'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif;
   background-color: chocolate;
-  font-size: 30px;
+  font-size: 2.2rem;
 }
 .container {
   max-width: 60%;
@@ -154,7 +140,7 @@ transition: all 0.3s ease;
 @media (min-width:768px){
   body{
     font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
-      font-size: 25px;
+      font-size: 1.8rem;
     }
     .bayan__radio:checked ~ .bayan__meme>.bayan__img{
       height: 15rem;
@@ -171,7 +157,7 @@ transition: all 0.3s ease;
 @media(min-width:1200px){
   body{
   font-family: Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
-    font-size: 20px;
+    font-size: 1.2rem;
   }
   .bayan__radio:checked ~ .bayan__meme>.bayan__img{
     height: 20rem;


### PR DESCRIPTION
1. Task:https://github.com/DrDiman/CSS-Bayan-task
2. Screenshot:
![Снимок экрана 2023-03-12 212821](https://user-images.githubusercontent.com/125154267/224568299-8bc72c86-fde4-4bc5-8330-c8b59fca203c.png)
3. Deploy: https://danesius.github.io/cssBayan/cssBayan/index.html
4. Done 12.03.2023 / deadline 13.03.2023
5. Score: 128 / 140
1.Everything is done from Repository requirements and how to submit task section +(20) fucked up with directories and time marks.
2.The accordion component is centered on the screen, with equal indents on the left and right +10
3.Icons, meme texts and meme images are exist +5
4.Placement of the meme, icons and meme text are the same as in provided example gif images +5
5.Smooth change (transition) of the meme images and icons is done +20
6.Responsive design with three breakpoints for mobile, tablet, and desktop exist. Accordion is displayed correctly at mobile 320x568, tablet 820x1180, desktop 1920×1080. (Note: breakpoints don't have to be 320x568, 820x1180, 1920x1080). +10
7.All visual effects when the cursor is hovering over the memes, when the mouse is down on a meme, and when a meme is selected are implemented +10
8.The entire row (text, icon, and meme image) clickable +5
9.Cursor over the memes (hover) effect only exists for devices that can support hover. +10
10.The cursor when it is hovering over the rows of the accordion is changing +5
11.Only flexible dimensions are used rem, em, %, vh, vw, fr and etc... The accordion is responsive +10
12.All blocks/parts of the accordion are in base flow of the dom elements. All elements are not positioned with top, left, right, bottom. float is not used. The value of position is only static +(3) used position: relative and position : absolute
13.Pseudo-elements are not used (note 1: pseudo-classes are allowed; note 2: pseudo-elements only from FontAwesome are allowed) +5
14.Initially, the first meme should be expanded +5
15.Font size is changed at each device (mobile, tablet, desktop) +5